### PR TITLE
Fix `prevBtnClass` + `nextBtnClass` configuration options

### DIFF
--- a/src/simpleLightbox.js
+++ b/src/simpleLightbox.js
@@ -338,8 +338,8 @@
                                     '<button type="button" title="' + o.closeBtnCaption + '" class="slbCloseBtn ' + o.closeBtnClass + '">×</button>' +
                                     (this.items.length > 1
                                         ? '<div class="slbArrows">' +
-                                             '<button type="button" title="' + o.prevBtnCaption + '" class="prev slbArrow' + o.prevBtnClass + '">' + o.prevBtnCaption + '</button>' +
-                                             '<button type="button" title="' + o.nextBtnCaption + '" class="next slbArrow' + o.nextBtnClass + '">' + o.nextBtnCaption + '</button>' +
+                                             '<button type="button" title="' + o.prevBtnCaption + '" class="prev slbArrow ' + o.prevBtnClass + '">' + o.prevBtnCaption + '</button>' +
+                                             '<button type="button" title="' + o.nextBtnCaption + '" class="next slbArrow ' + o.nextBtnClass + '">' + o.nextBtnCaption + '</button>' +
                                           '</div>'
                                         : ''
                                     ) +


### PR DESCRIPTION
Currently, there isn't enough spacing between the default CSS classes
for the next and previous buttons and a potential custom one, so if you
use of them, the class names get truncated together and stop working
like so:

``` html
<button ... class="next slbArrowmyCustomClass">
```

They should look like what the `closeBtnClass` above has with an extra
trailing space so that all classes appear correctly separated like so:

``` html
<button ... class="next slbArrow myCustomClass">
```

Note: I didn't regenerate anything in `dist/` (honestly, not sure how
to off hand), so this just comes into what's in `src/`.